### PR TITLE
`doc`: update `phonon.md` and `superconductivity.md` for stability criteria

### DIFF
--- a/public/contributions/phonon.md
+++ b/public/contributions/phonon.md
@@ -4,7 +4,7 @@
 
 Phonon dispersion is fundamental to understanding the physical properties of crystalline materials. They govern a wide range of phenomena, from thermal conductivity and heat capacity to thermal expansion and phase stability. A deep understanding of lattice dynamics is essential for predicting structural stability.
 
-The Materials Cloud three-dimensional database (MC3D) provides a vast catalog of experimentally synthesised structures. Comprehensive data on their dynamical properties remains a critical frontier. By leveraging density functional perturbation theory (DFPT), we can offer vital insights into their phase stability.
+The Materials Cloud three-dimensional database (MC3D) provides a vast catalog of experimentally synthesised structures. Comprehensive data on their dynamical properties remains a critical frontier. By leveraging  density functional perturbation theory (DFPT), we can offer vital insights into their phase stability.
 
 ## supercond-QE database
 
@@ -16,8 +16,8 @@ The dynamical matrices were calculated for 4533 non-magnetic metals, utilizing a
 
 ### Phonon calculation details
 
-We collected 2825 dynamical matrices from successful subproces `PhBaseWorkChain` originating from a five-step workchain for electron-phonon coupling.
-Based on the dynamical matrices, we performed subsequent `Q2rBaseWorkChain` and `MatdynBaseWorkChain` interpolation independently for the visualized phonon dispersion using the "all" acoustic sum rule[^2](https://www.quantum-espresso.org/Doc/INPUT_MATDYN.html#id4).
+We collected 2825 dynamical matrices from successful subproces `PhBaseWorkChain` originating from a five-step workchain for electron-phonon coupling. 
+Based on the dynamical matrices, we performed subsequent `Q2rBaseWorkChain` and `MatdynBaseWorkChain` interpolation independently for the visualized phonon dispersion using the "all" acoustic sum rull[^2](https://www.quantum-espresso.org/Doc/INPUT_MATDYN.html#id4). 
 The pseudopotentials used here are from SSSP library[^3] with the planewave cutoff ($E_{\textrm{cut}}$) being the highest value recommended by the library.
 
 In summary, the global workflow is:
@@ -27,9 +27,12 @@ In summary, the global workflow is:
 3. compute interatomic force constants.
 4. interpolate for visualized phonon dispersion.
 
+
 ---
 
 Other details:
+
+- We consider the material as computationally stable if the minimal phonon freqency $\omega^{\textrm{min}}$ from `MatdynBaseWorkChain` is above -1 meV.
 
 - Following convention $\omega^{\textrm{max}}$ refers to the maximum phonon frequency computed with density functional perturbation theory (DFPT).
 
@@ -44,3 +47,4 @@ Other details:
 [^2]: _asr all:_ Lin, C., Poncé, S. & Marzari, N. General invariance and equilibrium conditions for lattice dynamics in 1D, 2D, and 3D materials. npj Comput Mater 8, 236 (2022). https://doi.org/10.1038/s41524-022-00920-6
 
 [^3]: _SSSP Publication:_ Prandini, G., Marrazzo, A., Castelli, I.E. et al. Precision and efficiency in solid-state pseudopotential calculations. npj Comput Mater 4, 72 (2018). https://doi.org/10.1038/s41524-018-0127-2
+

--- a/public/contributions/phonon.md
+++ b/public/contributions/phonon.md
@@ -4,7 +4,7 @@
 
 Phonon dispersion is fundamental to understanding the physical properties of crystalline materials. They govern a wide range of phenomena, from thermal conductivity and heat capacity to thermal expansion and phase stability. A deep understanding of lattice dynamics is essential for predicting structural stability.
 
-The Materials Cloud three-dimensional database (MC3D) provides a vast catalog of experimentally synthesised structures. Comprehensive data on their dynamical properties remains a critical frontier. By leveraging  density functional perturbation theory (DFPT), we can offer vital insights into their phase stability.
+The Materials Cloud three-dimensional database (MC3D) provides a vast catalog of experimentally synthesised structures. Comprehensive data on their dynamical properties remains a critical frontier. By leveraging density functional perturbation theory (DFPT), we can offer vital insights into their phase stability.
 
 ## supercond-QE database
 
@@ -16,8 +16,8 @@ The dynamical matrices were calculated for 4533 non-magnetic metals, utilizing a
 
 ### Phonon calculation details
 
-We collected 2825 dynamical matrices from successful subproces `PhBaseWorkChain` originating from a five-step workchain for electron-phonon coupling. 
-Based on the dynamical matrices, we performed subsequent `Q2rBaseWorkChain` and `MatdynBaseWorkChain` interpolation independently for the visualized phonon dispersion using the "all" acoustic sum rull[^2](https://www.quantum-espresso.org/Doc/INPUT_MATDYN.html#id4). 
+We collected 2825 dynamical matrices from successful subproces `PhBaseWorkChain` originating from a five-step workchain for electron-phonon coupling.
+Based on the dynamical matrices, we performed subsequent `Q2rBaseWorkChain` and `MatdynBaseWorkChain` interpolation independently for the visualized phonon dispersion using the "all" acoustic sum rull[^2](https://www.quantum-espresso.org/Doc/INPUT_MATDYN.html#id4).
 The pseudopotentials used here are from SSSP library[^3] with the planewave cutoff ($E_{\textrm{cut}}$) being the highest value recommended by the library.
 
 In summary, the global workflow is:
@@ -26,7 +26,6 @@ In summary, the global workflow is:
 2. compute dynamical matrices via a phonon calculation.
 3. compute interatomic force constants.
 4. interpolate for visualized phonon dispersion.
-
 
 ---
 
@@ -47,4 +46,3 @@ Other details:
 [^2]: _asr all:_ Lin, C., Poncé, S. & Marzari, N. General invariance and equilibrium conditions for lattice dynamics in 1D, 2D, and 3D materials. npj Comput Mater 8, 236 (2022). https://doi.org/10.1038/s41524-022-00920-6
 
 [^3]: _SSSP Publication:_ Prandini, G., Marrazzo, A., Castelli, I.E. et al. Precision and efficiency in solid-state pseudopotential calculations. npj Comput Mater 4, 72 (2018). https://doi.org/10.1038/s41524-018-0127-2
-

--- a/public/contributions/superconductivity.md
+++ b/public/contributions/superconductivity.md
@@ -66,7 +66,7 @@ for **k**/**q**-grids the following holds true:
 - The Fine **q**-grid is obtained from Fourier/Wannier interpolation.
 
 Other details:
-
+- The material is identified as dynamically stable only if its minimal phonon frequency computed from EPW interpolation is more than -1 meV.
 - $\Delta_{n\mathbf{k}}(0)$ is the value of the superconducting gap (in meV), extrapolated at 0K. It is obtained from a fit of the anisotropic $T_c$ data with a BCS equation.
 - The smearing value (_Smearing-q_) refers to the _"degaussq"_ input variable in EPW and is the smearing over q in the electron-phonon coupling in meV.
 - The Fermi window refers to the states around the Fermi level included in the superconducting calculation, expressed in eV.

--- a/public/contributions/superconductivity.md
+++ b/public/contributions/superconductivity.md
@@ -66,6 +66,7 @@ for **k**/**q**-grids the following holds true:
 - The Fine **q**-grid is obtained from Fourier/Wannier interpolation.
 
 Other details:
+
 - The material is identified as dynamically stable only if its minimal phonon frequency computed from EPW interpolation is more than -1 meV.
 - $\Delta_{n\mathbf{k}}(0)$ is the value of the superconducting gap (in meV), extrapolated at 0K. It is obtained from a fit of the anisotropic $T_c$ data with a BCS equation.
 - The smearing value (_Smearing-q_) refers to the _"degaussq"_ input variable in EPW and is the smearing over q in the electron-phonon coupling in meV.


### PR DESCRIPTION
I added notes both in `phonon.md` and `superconductivity.md` that we consider phonon dispersion as stable when the minimal frequency is larger than -1 meV.